### PR TITLE
adjust Japanese translations to make more understandable, fix country…

### DIFF
--- a/lib/ja_JP.json
+++ b/lib/ja_JP.json
@@ -100,8 +100,8 @@
     },
     "zoom": {
         "actualSize": "実際のサイズ",
-        "pageFit": "ページに合わせます",
-        "pageWidth": "ページの幅",
+        "pageFit": "ページサイズに合わせる",
+        "pageWidth": "ウィンドウ幅に合わせる",
         "zoomDocument": "ドキュメントの表示を拡大し、縮小します",
         "zoomIn": "ズームイン",
         "zoomOut": "ズームアウト"


### PR DESCRIPTION
…/language code

The Japanese related to "Page Width" and "Page Fit" was confusing for my colleagues, and so I've updated it to something more understandable. 

Also, the same as for English we do "en_US", language code first, and then country code, for Japanese it ought to be, "ja_JP", where ja designates "Japanese" and JP designates "Japan." Unfortunately, moving the file will be a breaking change for anyone using the previous version, so I'm not sure what the best way to proceed is here. 