### PR TITLE
feat: Add Brazilian Portuguese translations and update scrollMode

### DIFF
--- a/lib/ar_AE.json
+++ b/lib/ar_AE.json
@@ -71,6 +71,10 @@
         "rotateForward": "تدور في اتجاه عقارب الساعة"
     },
     "scrollMode": {
+        "singlePage": "صفحة واحدة",
+        "dualPage": "صفحتان",
+        "dualPageCover": "صفحتان مع غلاف",
+        "pageScrolling": "تمرير الصفحة",
         "horizontalScrolling": "التمرير الأفقي",
         "verticalScrolling": "التمرير العمودي",
         "wrappedScrolling": "التمرير ملفوفة"

--- a/lib/de_DE.json
+++ b/lib/de_DE.json
@@ -71,6 +71,10 @@
         "rotateForward": "Im Uhrzeigersinn drehen"
     },
     "scrollMode": {
+        "singlePage": "Einzelseite",
+        "dualPage": "Doppelseite",
+        "dualPageCover": "Doppelseite mit Umschlag",
+        "pageScrolling": "Seitenweise scrollen",
         "horizontalScrolling": "Horizontales Scrollen",
         "verticalScrolling": "Vertikales Scrollen",
         "wrappedScrolling": "Umwickeltes Scrollen"

--- a/lib/en_US.json
+++ b/lib/en_US.json
@@ -71,6 +71,10 @@
         "rotateForward": "Rotate clockwise"
     },
     "scrollMode": {
+        "singlePage": "Single page",
+        "dualPage": "Dual page",
+        "dualPageCover": "Dual page with cover",
+        "pageScrolling": "Page scrolling",
         "horizontalScrolling": "Horizontal scrolling",
         "verticalScrolling": "Vertical scrolling",
         "wrappedScrolling": "Wrapped scrolling"

--- a/lib/es_ES.json
+++ b/lib/es_ES.json
@@ -71,6 +71,10 @@
         "rotateForward": "Rotar en sentido horario"
     },
     "scrollMode": {
+        "singlePage": "Página única",
+        "dualPage": "Página doble",
+        "dualPageCover": "Página doble con portada",
+        "pageScrolling": "Desplazamiento por página",
         "horizontalScrolling": "Desplazamiento horizontal",
         "verticalScrolling": "Desplazamiento vertical",
         "wrappedScrolling": "Desplazamiento en bloque"

--- a/lib/fr_FR.json
+++ b/lib/fr_FR.json
@@ -71,6 +71,10 @@
         "rotateForward": "Tourner en avant"
     },
     "scrollMode": {
+        "singlePage": "Page unique",
+        "dualPage": "Deux pages",
+        "dualPageCover": "Deux pages avec couverture",
+        "pageScrolling": "Défilement de page",
         "horizontalScrolling": "Défilement horizontal",
         "verticalScrolling": "Défilement vertical",
         "wrappedScrolling": "Défilement de nombreuses pages"

--- a/lib/it_IT.json
+++ b/lib/it_IT.json
@@ -71,6 +71,10 @@
         "rotateForward": "Ruotare in senso orario"
     },
     "scrollMode": {
+        "singlePage": "Pagina singola",
+        "dualPage": "Due pagine",
+        "dualPageCover": "Due pagine con copertina",
+        "pageScrolling": "Scorrimento pagina",
         "horizontalScrolling": "Scorrimento orizzontale",
         "verticalScrolling": "Scorrimento verticale",
         "wrappedScrolling": "Scorrimento avvolto"

--- a/lib/jp_JP.json
+++ b/lib/jp_JP.json
@@ -71,6 +71,10 @@
         "rotateForward": "時計回りに回転します"
     },
     "scrollMode": {
+        "singlePage": "単一ページ",
+        "dualPage": "2ページ",
+        "dualPageCover": "カバーページ付きの2ページ",
+        "pageScrolling": "ページスクロール",
         "horizontalScrolling": "水平スクロール",
         "verticalScrolling": "垂直スクロール",
         "wrappedScrolling": "ラップされたスクロール"

--- a/lib/ko_KR.json
+++ b/lib/ko_KR.json
@@ -71,6 +71,10 @@
         "rotateForward": "시계 방향으로 회전"
     },
     "scrollMode": {
+        "singlePage": "단일 페이지",
+        "dualPage": "이중 페이지",
+        "dualPageCover": "이중 페이지(표지 포함)",
+        "pageScrolling": "페이지 스크롤링",
         "horizontalScrolling": "수평 스크롤링",
         "verticalScrolling": "수직 스크롤링",
         "wrappedScrolling": "자동줄바꿈 스크롤링"

--- a/lib/pt_BR.json
+++ b/lib/pt_BR.json
@@ -1,0 +1,113 @@
+{
+  "attachment": {
+    "clickToDownload": "Clique para baixar",
+    "noAttachment": "Não há anexo"
+  },
+  "bookmark": {
+    "noBookmark": "Não há marcador"
+  },
+  "core": {
+    "askingPassword": {
+      "requirePasswordToOpen": "Este documento requer uma senha para abrir",
+      "submit": "Enviar"
+    },
+    "wrongPassword": {
+      "submit": "Enviar",
+      "tryAgain": "A senha está incorreta. Tente novamente, por favor."
+    },
+    "pageLabel": "Página {{pageIndex}}"
+  },
+  "defaultLayout": {
+    "attachment": "Anexo",
+    "bookmark": "Marcador",
+    "thumbnail": "Miniatura"
+  },
+  "download": {
+    "download": "Baixar"
+  },
+  "drop": {
+    "dragDropFile": "Arraste e solte um documento PDF aqui"
+  },
+  "fullScreen": {
+    "enterFullScreen": "Entrar no modo tela cheia",
+    "exitFullScreen": "Sair do modo tela cheia"
+  },
+  "localeSwitcher": {
+    "switchLocale": "Mudar idioma"
+  },
+  "open": {
+    "openFile": "Abrir arquivo"
+  },
+  "pageNavigation": {
+    "enterPageNumber": "Digite um número de página",
+    "goToFirstPage": "Primeira página",
+    "goToLastPage": "Última página",
+    "goToNextPage": "Próxima página",
+    "goToPreviousPage": "Página anterior"
+  },
+  "print": {
+    "cancel": "Cancelar",
+    "preparingDocument": "Preparando documento",
+    "print": "Imprimir"
+  },
+  "properties": {
+    "author": "Autor",
+    "close": "Fechar",
+    "creationDate": "Data de criação",
+    "creator": "Criador",
+    "fileName": "Nome do arquivo",
+    "fileSize": "Tamanho do arquivo",
+    "keywords": "Palavras-chave",
+    "modificationDate": "Data de modificação",
+    "pageCount": "Quantidade de páginas",
+    "pdfProducer": "Produtor PDF",
+    "pdfVersion": "Versão PDF",
+    "showProperties": "Mostrar propriedades",
+    "subject": "Assunto",
+    "title": "Título"
+  },
+  "rotate": {
+    "rotateBackward": "Girar no sentido anti-horário",
+    "rotateForward": "Girar no sentido horário"
+  },
+  "scrollMode": {
+    "singlePage": "Página única",
+    "dualPage": "Duas páginas",
+    "dualPageCover": "Duas páginas com capa",
+    "pageScrolling": "Rolagem de página",
+    "horizontalScrolling": "Rolagem horizontal",
+    "verticalScrolling": "Rolagem vertical",
+    "wrappedScrolling": "Rolagem contínua"
+  },
+  "search": {
+    "close": "Fechar",
+    "enterToSearch": "Digite para pesquisar",
+    "matchCase": "Diferenciar maiúsculas/minúsculas",
+    "nextMatch": "Próxima correspondência",
+    "previousMatch": "Correspondência anterior",
+    "search": "Pesquisar",
+    "wholeWords": "Palavras completas"
+  },
+  "selectionMode": {
+    "handTool": "Ferramenta de mão",
+    "textSelectionTool": "Ferramenta de seleção de texto"
+  },
+  "theme": {
+    "switchDarkTheme": "Ativar modo escuro",
+    "switchLightTheme": "Ativar modo claro"
+  },
+  "thumbnail": {
+    "thumbnailLabel": "Miniatura da página {{pageIndex}}"
+  },
+  "toolbar": {
+    "moreActions": "Mais ações"
+  },
+  "zoom": {
+    "actualSize": "Tamanho real",
+    "pageFit": "Ajustar à página",
+    "pageWidth": "Largura da página",
+    "zoomDocument": "Zoom no documento",
+    "zoomIn": "Aumentar zoom",
+    "zoomOut": "Reduzir zoom"
+  }
+}

--- a/lib/pt_PT.json
+++ b/lib/pt_PT.json
@@ -71,6 +71,10 @@
         "rotateForward": "Girar no sentido horário"
     },
     "scrollMode": {
+        "singlePage": "Página única",
+        "dualPage": "Página dupla",
+        "dualPageCover": "Página dupla com capa",
+        "pageScrolling": "Rolagem de página",
         "horizontalScrolling": "Rolagem horizontal",
         "verticalScrolling": "Rolagem vertical",
         "wrappedScrolling": "Rolagem envolvida"

--- a/lib/ru_RU.json
+++ b/lib/ru_RU.json
@@ -71,6 +71,10 @@
         "rotateForward": "Вращаться по часовой стрелке"
     },
     "scrollMode": {
+        "singlePage": "Одинарная страница",
+        "dualPage": "Двойная страница",
+        "dualPageCover": "Двойная страница с обложкой",
+        "pageScrolling": "Прокрутка страницы",
         "horizontalScrolling": "Горизонтальная прокрутка",
         "verticalScrolling": "Вертикальная прокрутка",
         "wrappedScrolling": "Прокрутка с переносом"
@@ -104,6 +108,6 @@
         "pageWidth": "Ширина страницы",
         "zoomDocument": "Увеличить документ",
         "zoomIn": "Приблизить",
-        "zoomOut": "Уменьшить"
+        "zoomOut": "Отдалить"
     }
 }

--- a/lib/vi_VN.json
+++ b/lib/vi_VN.json
@@ -71,6 +71,10 @@
         "rotateForward": "Xoay chiều kim đồng hồ"
     },
     "scrollMode": {
+        "singlePage": "Trang đơn",
+        "dualPage": "Hai trang",
+        "dualPageCover": "Bìa đôi",
+        "pageScrolling": "Cuộn trang",
         "horizontalScrolling": "Cuộn ngang",
         "verticalScrolling": "Cuộn dọc",
         "wrappedScrolling": "Cuộn lưới"

--- a/lib/zh_CN.json
+++ b/lib/zh_CN.json
@@ -71,6 +71,10 @@
         "rotateForward": "顺时针旋转"
     },
     "scrollMode": {
+        "singlePage": "单页",
+        "dualPage": "双页",
+        "dualPageCover": "封面双页",
+        "pageScrolling": "页面滚动",
         "horizontalScrolling": "水平滚动",
         "verticalScrolling": "垂直滚动",
         "wrappedScrolling": "环绕滚动"

--- a/lib/zh_TW.json
+++ b/lib/zh_TW.json
@@ -71,6 +71,10 @@
         "rotateForward": "順時針旋轉"
     },
     "scrollMode": {
+        "singlePage": "單頁",
+        "dualPage": "雙頁",
+        "dualPageCover": "封面雙頁",
+        "pageScrolling": "頁面滾動",
         "horizontalScrolling": "水平滾動",
         "verticalScrolling": "垂直滾動",
         "wrappedScrolling": "環繞滾動"


### PR DESCRIPTION
## Summary of Additions

### Addition of New Translation in `pt_BR.json`:
A new translation file named `pt_BR.json` has been added to the repository, providing Brazilian Portuguese translations for various user interface elements in the library.

### Addition of Properties in `scrollMode`:
The following properties were added to the `scrollMode` section in all translation files:
- `"singlePage"`
- `"dualPage"`
- `"dualPageCover"`
- `"pageScrolling"`

This addition addresses an issue where, prior to this update, some button labels were appearing blank when a translation was used. The newly added properties ensure that users have complete and coherent options for scroll modes, enhancing the user experience.

These changes significantly improve the accessibility and usability of the library for Portuguese-speaking users, ensuring that all relevant interface elements are properly translated and functional.
